### PR TITLE
Extend suspicious gift message to filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relay-bot",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "",
   "main": "run.js",
   "scripts": {

--- a/src/Modules/SpamProtection/SuspiciousMessageFilter.ts
+++ b/src/Modules/SpamProtection/SuspiciousMessageFilter.ts
@@ -13,8 +13,17 @@ export class SuspiciousMessageFilter {
             return true
         }
 
-        let regexp = new RegExp('http.*:\\/\\/.*steam')
-        return regexp.test(msg.message);
+        const regexpSteam = new RegExp('http.*:\\/\\/.*steam');
+        const regexpGift = new RegExp(/\.gift\s/);
+
+        let flag = regexpSteam.test(msg.message);
+        if (flag) {
+            return flag;
+        }
+
+        flag = regexpGift.test(msg.message);
+
+        return flag;
     }
 
     private isNewcomer(msg: DiscordMessage)


### PR DESCRIPTION
Added regexp for filtering messages with the exact `.gift` word in it. Consider such messages as `suspicious` and returning `true` flag from the following method.